### PR TITLE
dont stop on healthd

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -107,7 +107,7 @@ func (a *Agent) loopSyncMonitors() {
 		case <-time.After(time.Duration(a.config.SyncHealthdInterval) * time.Second):
 			err := a.syncMonitors(false)
 			if err != nil {
-				logrus.Panicf("couldn't sync monitors, aborting execution since state may be fucked, see: %v", err)
+				logrus.Errorf("couldn't sync monitors, see: %v", err)
 			}
 		}
 	}


### PR DESCRIPTION
We should not quite on restart of healthd, or unavailability of data in etcd, or unavailable etcd.